### PR TITLE
Fix MessagePackReader for multi-segment strings

### DIFF
--- a/src/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack/MessagePackReader.cs
@@ -805,6 +805,7 @@ namespace MessagePack
                     }
                 }
 #endif
+                reader.Advance(bytesRead);
             }
 
             string value = new string(charArray, 0, initializedChars);

--- a/src/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack/MessagePackReader.cs
@@ -805,7 +805,7 @@ namespace MessagePack
                     }
                 }
 #endif
-                reader.Advance(bytesRead);
+                this.reader.Advance(bytesRead);
             }
 
             string value = new string(charArray, 0, initializedChars);

--- a/tests/MessagePack.Tests/MessagePackReaderTests.ReadString.cs
+++ b/tests/MessagePack.Tests/MessagePackReaderTests.ReadString.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Buffers;
+using Xunit;
+
+namespace MessagePack.Tests
+{
+    partial class MessagePackReaderTests
+    {
+        [Fact]
+        public void ReadString_HandlesSingleSegment()
+        {
+            var seq = BuildSequence(new[] {
+                (byte)(MessagePackCode.MinFixStr + 2),
+                (byte)'A', (byte)'B' });
+
+            var reader = new MessagePackReader(seq);
+            var result = reader.ReadString();
+            Assert.Equal("AB", result);
+        }
+
+        [Fact]
+        public void ReadString_HandlesMultipleSegments()
+        {
+            var seq = BuildSequence(
+                new[] { (byte)(MessagePackCode.MinFixStr + 2), (byte)'A' },
+                new[] { (byte)'B' });
+
+            var reader = new MessagePackReader(seq);
+            var result = reader.ReadString();
+            Assert.Equal("AB", result);
+        }
+
+        ReadOnlySequence<T> BuildSequence<T>(params T[][] segmentContents)
+        {
+            var segments = new TestSequenceSegment<T>[segmentContents.Length];
+            TestSequenceSegment<T> last = null;
+            for (var i = 0; i < segmentContents.Length; i++)
+            {
+                last = segments[i] = new TestSequenceSegment<T>(segmentContents[i], last);
+            }
+
+            return new ReadOnlySequence<T>(segments[0], 0, last, last.Memory.Length);
+        }
+
+        class TestSequenceSegment<T> : ReadOnlySequenceSegment<T>
+        {
+            public TestSequenceSegment(T[] data, TestSequenceSegment<T> prev = null)
+            {
+                Memory = new Memory<T>(data);
+
+                if (prev != null)
+                {
+                    prev.Next = this;
+                    RunningIndex = prev.RunningIndex + prev.Memory.Length;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This fixes an issue reported in server-side Blazor whereby it would sometimes abort connections when the server was under high traffic: https://github.com/aspnet/AspNetCore/issues/6385. The SignalR hub was receiving corrupted messages, e.g., to invoke a hub method called `OnOnOnOnOnOnOnOnO` (should be `OnRenderCompleted`).

The bug is that `MessagePackReader` has two ways of reading strings: fast path (used when the sequence reader contains only one span), and slow path (used when it has multiple spans), but only the fast path actually works. The slow path code will always produce corrupted results, because it doesn't advance the reader each time it gets some bytes from it.

AFAICT there were no tests for `MessagePackReader`'s string handling, so I've added a couple of basic ones. However it's not my goal to create a complete test suite for `MessagePackReader` in this PR, of course!